### PR TITLE
Fix styles of the language selector

### DIFF
--- a/nuidentity-card-editor/src/container/MainForm.tsx
+++ b/nuidentity-card-editor/src/container/MainForm.tsx
@@ -8,8 +8,8 @@ const MainForm: React.FC = () => {
   const { t, i18n } = useTranslation();
   const changeLanguage = (lang : string) => i18n.changeLanguage(lang);
   const btnLinkStyleOverrides = {
-    margin: "0px !important",
-    padding: "0px !important"
+    margin: "0px",
+    padding: "0px"
   }
 
   return <Container>


### PR DESCRIPTION
Sorry to bother again, but I just realized that the code I merged contained a small styling problem with the language selector:
- "!important" actually causes the styles to fail to load with React
- removed "!important" causes the styles to load

Sincerely